### PR TITLE
Added key needed for audio recording mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -195,6 +195,7 @@ class App extends React.Component {
       allowsRecordingIOS: false,
       interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
       playsInSilentModeIOS: true,
+      playsInSilentLockedModeIOS: true,
       shouldDuckAndroid: true,
       interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
     });


### PR DESCRIPTION
Without the playsInSilentLockedModeIOS an error is thrown in Android emulator with Genymotion