### PR TITLE
Upgrade to Expo SDK v34.0.0

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,7 +12,11 @@ import {
   TouchableHighlight,
   View,
 } from 'react-native';
-import Expo, { Asset, Audio, FileSystem, Font, Permissions } from 'expo';
+import { Asset } from 'expo-asset';
+import { Audio } from 'expo-av';
+import * as FileSystem from 'expo-file-system';
+import * as Font from 'expo-font';
+import * as Permissions from 'expo-permissions';
 
 class Icon {
   constructor(module, width, height) {
@@ -145,6 +149,8 @@ export default class App extends React.Component {
       playsInSilentModeIOS: true,
       shouldDuckAndroid: true,
       interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+      playThroughEarpieceAndroid: false,
+      staysActiveInBackground: true,
     });
     if (this.recording !== null) {
       this.recording.setOnRecordingStatusUpdate(null);
@@ -180,8 +186,10 @@ export default class App extends React.Component {
       playsInSilentLockedModeIOS: true,
       shouldDuckAndroid: true,
       interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+      playThroughEarpieceAndroid: false,
+      staysActiveInBackground: true,
     });
-    const { sound, status } = await this.recording.createNewLoadedSound(
+    const { sound, status } = await this.recording.createNewLoadedSoundAsync(
       {
         isLooping: true,
         isMuted: this.state.muted,
@@ -584,5 +592,3 @@ const styles = StyleSheet.create({
     width: DEVICE_WIDTH / 2.0,
   },
 });
-
-Expo.registerRootComponent(App);

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "Hear me now.",
     "slug": "record",
     "privacy": "public",
-    "sdkVersion": "27.0.0",
+    "sdkVersion": "34.0.0",
     "version": "1.0.0",
     "orientation": "portrait",
     "primaryColor": "#cccccc",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,19 @@
   "author": null,
   "private": true,
   "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "eject": "expo eject"
+  },
   "dependencies": {
-    "expo": "^27.0.0",
-    "react": "16.3.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-27.0.0.tar.gz"
+    "expo": "^34.0.1",
+    "expo-asset": "^6.0.0",
+    "expo-av": "~6.0.0",
+    "expo-file-system": "~6.0.0",
+    "expo-permissions": "~6.0.0",
+    "react": "16.8.3",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-34.0.0.tar.gz"
   }
 }


### PR DESCRIPTION
Why                                                                                                                                                                                       
 ---                                                                                                                                                                                      
The demo should be available to run on the latest version of Expo.                                                                                                                        
                                                                                                                                                                                          
How                                                                                                                                                                                       
 ---                                                                                                                                                                                      
* I updated the sdkVersion in app.json.                                                                                                                                                   
* I updated the dependencies in package.json.                                                                                                                                             
* I added a `scripts` section to package.json based on those added to a                                                                                                                   
  new project created with `expo init`.                                                                                                                                                   
* I updated App.js to fix breaking changes in the SDKs between v27 and                                                                                                                    
  v34, as per the release notes.                                                                                                                                                          
                                                                                                                                                                                          
Test Plan                                                                                                                                                                                 
 ---                                                                                                                                                                                      
I ran the project with `yarn start` on an Android phone using Expo                                                                                                                        
client version 2.12.0.                                                                                                                                                                    
I was prompted to allow recording, after which I tested recording and                                                                                                                     
playback functionality to ensure the correct behaviour.                                                                                                                                   
